### PR TITLE
Update sharp version for Node v13 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "mongoose": "^5.8.1",
         "multer": "^1.4.1",
         "rootpath": "^0.1.2",
-        "sharp": "^0.22.1"
+        "sharp": "^0.25.2"
     },
     "devDependencies": {
         "nodemon": "^1.17.5"


### PR DESCRIPTION
Update `sharp` version to `0.25.x` for Node v13 compatibility